### PR TITLE
MySQL Slowlog の取得と解析の準備

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+mysql.digest.txt

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,15 @@ deploy-conf:
 	ssh root@isucon1 systemctl restart isuride-go
 	ssh root@isucon1 systemctl restart isuride-matcher
 
+install-percona-toolkit:
+	sudo apt install -y percona-toolkit
+
+enable-mysql-slowlog:
+	ssh isucon1 sudo truncate -c -s 0 /tmp/slow.log
+	ssh isucon1 'sudo mysql -e "SET GLOBAL long_query_time = 0; SET GLOBAL slow_query_log = ON; SET GLOBAL slow_query_log_file = \"/tmp/slow.log\";"'
+
+disable-mysql-slowlog:
+	ssh isucon1 'sudo mysql -e "SET GLOBAL slow_query_log = OFF"'
+
+get-mysql-slowlog:
+	ssh root@isucon1 gzip -c /tmp/slow.log | gzip -dc | pt-query-digest > mysql.digest.txt


### PR DESCRIPTION
This pull request includes changes to the `Makefile` to add new commands for managing MySQL slow logs and installing Percona Toolkit.

New commands added:

* [`install-percona-toolkit`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R24-R35): A command to install Percona Toolkit using `apt`.
* [`enable-mysql-slowlog`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R24-R35): Commands to enable MySQL slow query logging and set the log file location.
* [`disable-mysql-slowlog`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R24-R35): A command to disable MySQL slow query logging.
* [`get-mysql-slowlog`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R24-R35): A command to retrieve and process the MySQL slow log using `pt-query-digest`.