### PR TITLE
エラー発生時にStacktraceをエラーログに出力

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -173,6 +173,17 @@ func writeError(w http.ResponseWriter, statusCode int, err error) {
 	w.Write(buf)
 
 	slog.Error("error response wrote", err)
+
+	for i := 1; ; i++ {
+		pt, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		funcName := runtime.FuncForPC(pt).Name()
+		if strings.HasPrefix(funcName, "main.") {
+			slog.Error(fmt.Sprintf("file: %s:%d (%v)\n", file, line, funcName))
+		}
+	}
 }
 
 func secureRandomStr(b int) string {


### PR DESCRIPTION
This pull request includes a change to enhance error logging in the `writeError` function. The change adds detailed stack trace information to the error logs, which will help in debugging by providing more context about where the error occurred.

Enhancements to error logging:

* [`go/main.go`](diffhunk://#diff-a240b23c8c4a5b71406f4393240035163be74a3840d5fdaa4b2a993872e8cf65R176-R186): In the `writeError` function, added a loop to capture and log the stack trace, including the file name, line number, and function name for each stack frame. This additional information is logged only for functions that are part of the `main` package.