### PR TITLE
イスの最新位置と累積移動距離をDBに保存し、その情報を活用して ownerGetChairs を高速化

### DIFF
--- a/go/owner_handlers.go
+++ b/go/owner_handlers.go
@@ -195,28 +195,14 @@ func ownerGetChairs(w http.ResponseWriter, r *http.Request) {
 	owner := ctx.Value("owner").(*Owner)
 
 	chairs := []chairWithDetail{}
-	if err := db.SelectContext(ctx, &chairs, `SELECT id,
-       owner_id,
-       name,
-       access_token,
-       model,
-       is_active,
-       created_at,
-       updated_at,
-       IFNULL(total_distance, 0) AS total_distance,
-       total_distance_updated_at
-FROM chairs
-       LEFT JOIN (SELECT chair_id,
-                          SUM(IFNULL(distance, 0)) AS total_distance,
-                          MAX(created_at)          AS total_distance_updated_at
-                   FROM (SELECT chair_id,
-                                created_at,
-                                ABS(latitude - LAG(latitude) OVER (PARTITION BY chair_id ORDER BY id)) +
-                                ABS(longitude - LAG(longitude) OVER (PARTITION BY chair_id ORDER BY id)) AS distance
-                         FROM chair_locations) tmp
-                   GROUP BY chair_id) distance_table ON distance_table.chair_id = chairs.id
-WHERE owner_id = ?
-`, owner.ID); err != nil {
+	if err := db.SelectContext(ctx, &chairs, `SELECT
+	    chairs.id, owner_id, name, access_token, model, is_active,
+        chairs.created_at, chairs.updated_at,
+        IFNULL(total_distance, 0) total_distance,
+        chairs_ex.total_distance_updated_at
+        FROM chairs
+          LEFT JOIN chairs_ex ON chairs.id = chairs_ex.id 
+        WHERE owner_id = ?`, owner.ID); err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}


### PR DESCRIPTION
This pull request includes changes to the `go/owner_handlers.go` and `sql/1-schema.sql` files to improve the handling and storage of chair data. The most important changes involve modifying how chair details are retrieved and adding a new table to store extended chair information.

### Improvements to chair data retrieval:

* [`go/owner_handlers.go`](diffhunk://#diff-25b0e3bde7a7cc9ad6f992bda223427958329b92d00817656fbd428f0a8b5a42L198-R205): Simplified the SQL query in the `ownerGetChairs` function by joining with the new `chairs_ex` table to retrieve extended chair details.

### Database schema enhancements:

* [`sql/1-schema.sql`](diffhunk://#diff-934bdc98e604a79c3b28e1056ed122c38c3bed7d1ae6517b2b7e1214175cbe06R141-R175): Added a new table `chairs_ex` to store extended information about chairs, including latitude, longitude, location count, and total distance updated timestamp.
* [`sql/1-schema.sql`](diffhunk://#diff-934bdc98e604a79c3b28e1056ed122c38c3bed7d1ae6517b2b7e1214175cbe06R141-R175): Created a trigger `after_chair_location_insert` to update the `chairs_ex` table whenever a new chair location is inserted, ensuring that the total distance and location details are accurately maintained.