### PR TITLE
DB設定チューニング: InterpolateParams = true / 接続数=100

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -60,6 +60,7 @@ func setup() http.Handler {
 	dbConfig.Net = "tcp"
 	dbConfig.DBName = dbname
 	dbConfig.ParseTime = true
+	dbConfig.InterpolateParams = true
 
 	_db, err := sqlx.Connect("mysql", dbConfig.FormatDSN())
 	if err != nil {

--- a/go/main.go
+++ b/go/main.go
@@ -66,6 +66,8 @@ func setup() http.Handler {
 	if err != nil {
 		panic(err)
 	}
+	_db.SetMaxIdleConns(100)
+	_db.SetMaxOpenConns(100)
 	db = _db
 
 	mux := chi.NewRouter()


### PR DESCRIPTION
This pull request includes changes to the database configuration in the `setup` function of `go/main.go`. The most important changes include enabling parameter interpolation and setting the maximum number of idle and open connections for the database.

Database configuration improvements:

* Enabled parameter interpolation by setting `dbConfig.InterpolateParams` to `true`.
* Configured the database connection pool by setting `SetMaxIdleConns` and `SetMaxOpenConns` to `100`.