### PR TITLE
ridesの最新statusをDBに保存するようにして、処理を高速化

### DIFF
--- a/go/chair_handlers.go
+++ b/go/chair_handlers.go
@@ -128,17 +128,13 @@ func chairPostCoordinate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ride := &Ride{}
-	if err := tx.GetContext(ctx, ride, `SELECT * FROM rides WHERE chair_id = ? ORDER BY updated_at DESC LIMIT 1`, chair.ID); err != nil {
+	if err := tx.GetContext(ctx, ride, `SELECT * FROM rides_with_status WHERE chair_id = ? ORDER BY updated_at DESC LIMIT 1`, chair.ID); err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			writeError(w, http.StatusInternalServerError, err)
 			return
 		}
 	} else {
-		status, err := getLatestRideStatus(ctx, tx, ride.ID)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err)
-			return
-		}
+		status := ride.Status
 		if status != "COMPLETED" && status != "CANCELED" {
 			if req.Latitude == ride.PickupLatitude && req.Longitude == ride.PickupLongitude && status == "ENROUTE" {
 				if _, err := tx.ExecContext(ctx, "INSERT INTO ride_statuses (id, ride_id, status) VALUES (?, ?, ?)", ulid.Make().String(), ride.ID, "PICKUP"); err != nil {
@@ -198,7 +194,7 @@ func chairGetNotification(w http.ResponseWriter, r *http.Request) {
 	yetSentRideStatus := RideStatus{}
 	status := ""
 
-	if err := tx.GetContext(ctx, ride, `SELECT * FROM rides WHERE chair_id = ? ORDER BY updated_at DESC LIMIT 1`, chair.ID); err != nil {
+	if err := tx.GetContext(ctx, ride, `SELECT * FROM rides_with_status WHERE chair_id = ? ORDER BY updated_at DESC LIMIT 1`, chair.ID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeJSON(w, http.StatusOK, &chairGetNotificationResponse{
 				RetryAfterMs: 30,
@@ -211,11 +207,7 @@ func chairGetNotification(w http.ResponseWriter, r *http.Request) {
 
 	if err := tx.GetContext(ctx, &yetSentRideStatus, `SELECT * FROM ride_statuses WHERE ride_id = ? AND chair_sent_at IS NULL ORDER BY id ASC LIMIT 1`, ride.ID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			status, err = getLatestRideStatus(ctx, tx, ride.ID)
-			if err != nil {
-				writeError(w, http.StatusInternalServerError, err)
-				return
-			}
+			status = ride.Status
 		} else {
 			writeError(w, http.StatusInternalServerError, err)
 			return
@@ -289,7 +281,7 @@ func chairPostRideStatus(w http.ResponseWriter, r *http.Request) {
 	defer tx.Rollback()
 
 	ride := &Ride{}
-	if err := tx.GetContext(ctx, ride, "SELECT * FROM rides WHERE id = ? FOR UPDATE", rideID); err != nil {
+	if err := tx.GetContext(ctx, ride, "SELECT * FROM rides_with_status WHERE id = ? FOR UPDATE", rideID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeError(w, http.StatusNotFound, errors.New("ride not found"))
 			return
@@ -312,11 +304,7 @@ func chairPostRideStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	// After Picking up user
 	case "CARRYING":
-		status, err := getLatestRideStatus(ctx, tx, ride.ID)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err)
-			return
-		}
+		status := ride.Status
 		if status != "PICKUP" {
 			writeError(w, http.StatusBadRequest, errors.New("chair has not arrived yet"))
 			return

--- a/go/models.go
+++ b/go/models.go
@@ -58,6 +58,8 @@ type Ride struct {
 	Evaluation           *int           `db:"evaluation"`
 	CreatedAt            time.Time      `db:"created_at"`
 	UpdatedAt            time.Time      `db:"updated_at"`
+	Status               string         `db:"status"`
+	StatusUpdatedAt      time.Time      `db:"status_updated_at"`
 }
 
 type RideStatus struct {

--- a/sql/1-schema.sql
+++ b/sql/1-schema.sql
@@ -154,6 +154,17 @@ CREATE TABLE chairs_ex
 )
   COMMENT = '椅子情報テーブルの追加情報';
 
+DROP TABLE IF EXISTS rides_ex;
+CREATE TABLE rides_ex
+(
+  id                   VARCHAR(26) NOT NULL COMMENT 'ライドID',
+  status               ENUM ('MATCHING', 'ENROUTE', 'PICKUP', 'CARRYING', 'ARRIVED', 'COMPLETED') NOT NULL COMMENT '状態',
+  status_count         INTEGER  NOT NULL,
+  status_updated_at    DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) COMMENT '更新日時',
+  PRIMARY KEY (id)
+)
+  COMMENT = 'ライド情報テーブルの追加情報';
+
 DELIMITER //
 
 CREATE TRIGGER after_chair_location_insert
@@ -168,6 +179,18 @@ BEGIN
     longitude = NEW.longitude,
     location_count = location_count + 1,
     total_distance_updated_at = NEW.created_at;
+END;
+
+CREATE TRIGGER after_ride_statuses_insert
+AFTER INSERT ON ride_statuses
+FOR EACH ROW
+BEGIN
+  INSERT INTO rides_ex (id, status, status_count, status_updated_at)
+  VALUES (NEW.ride_id, NEW.status, 1, NEW.created_at)
+  ON DUPLICATE KEY UPDATE
+    status = NEW.status,
+    status_count = status_count + 1,
+    status_updated_at = NEW.created_at;
 END;
 
 //

--- a/sql/1-schema.sql
+++ b/sql/1-schema.sql
@@ -196,3 +196,8 @@ END;
 //
 
 DELIMITER ;
+
+--
+
+DROP VIEW IF EXISTS rides_with_status;
+CREATE VIEW rides_with_status AS SELECT rides.*, rides_ex.status, rides_ex.status_updated_at FROM rides LEFT JOIN rides_ex ON rides.id = rides_ex.id;


### PR DESCRIPTION
This pull request includes significant changes to the handling of ride statuses in the codebase. The changes primarily involve replacing direct status queries with a new `rides_with_status` view and simplifying the code by removing redundant status fetching logic.

### Database and View Changes:
* Added a new table `rides_ex` to store ride status information and a trigger to update this table on status changes. [[1]](diffhunk://#diff-934bdc98e604a79c3b28e1056ed122c38c3bed7d1ae6517b2b7e1214175cbe06R157-R167) [[2]](diffhunk://#diff-934bdc98e604a79c3b28e1056ed122c38c3bed7d1ae6517b2b7e1214175cbe06R184-R203)
* Created a new view `rides_with_status` to join `rides` with `rides_ex` for easier status retrieval.

### Codebase Updates:
* Updated SQL queries in various functions to use the new `rides_with_status` view instead of the `rides` table. [[1]](diffhunk://#diff-9f2af22d3309447574fc39ea1127a4554aec1192c2cd71c40bb7d3fac6d9d690L206-R206) [[2]](diffhunk://#diff-9f2af22d3309447574fc39ea1127a4554aec1192c2cd71c40bb7d3fac6d9d690L317-R320) [[3]](diffhunk://#diff-9f2af22d3309447574fc39ea1127a4554aec1192c2cd71c40bb7d3fac6d9d690L530-R530) [[4]](diffhunk://#diff-9f2af22d3309447574fc39ea1127a4554aec1192c2cd71c40bb7d3fac6d9d690L673-R661) [[5]](diffhunk://#diff-9f2af22d3309447574fc39ea1127a4554aec1192c2cd71c40bb7d3fac6d9d690L892-R884) [[6]](diffhunk://#diff-f0044ecec93f1b03be29c21b03ef3c3e9ff1d2d1df08c1acb6e49bb8b9e7f3aeL131-R137) [[7]](diffhunk://#diff-f0044ecec93f1b03be29c21b03ef3c3e9ff1d2d1df08c1acb6e49bb8b9e7f3aeL201-R197) [[8]](diffhunk://#diff-f0044ecec93f1b03be29c21b03ef3c3e9ff1d2d1df08c1acb6e49bb8b9e7f3aeL292-R284)
* Removed redundant calls to `getLatestRideStatus` and replaced them with direct access to the `Status` field from the new view. [[1]](diffhunk://#diff-9f2af22d3309447574fc39ea1127a4554aec1192c2cd71c40bb7d3fac6d9d690L215-R215) [[2]](diffhunk://#diff-9f2af22d3309447574fc39ea1127a4554aec1192c2cd71c40bb7d3fac6d9d690L688-R676) [[3]](diffhunk://#diff-f0044ecec93f1b03be29c21b03ef3c3e9ff1d2d1df08c1acb6e49bb8b9e7f3aeL214-R210) [[4]](diffhunk://#diff-f0044ecec93f1b03be29c21b03ef3c3e9ff1d2d1df08c1acb6e49bb8b9e7f3aeL315-R307)

### Model Changes:
* Added `Status` and `StatusUpdatedAt` fields to the `Ride` struct to accommodate the new status information.