### PR TITLE
インフラ・ミドルウェア 設定

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,6 @@ install-kataribe:
 
 exec-kataribe:
 	ssh root@isucon1 gzip -c /var/log/nginx/access.log | gzip -dc | kataribe > kataribe.txt
+
+install-redis:
+	ssh root@isucon1 sudo apt install -y redis-server

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ deploy-conf:
 	rsync -v etc/mysql/my.cnf root@isucon1:/etc/mysql/my.cnf
 	rsync -v etc/systemd/system/isuride-go.service root@isucon1:/etc/systemd/system/isuride-go.service
 	rsync -v etc/systemd/system/isuride-matcher.service root@isucon1:/etc/systemd/system/isuride-matcher.service
+	ssh root@isucon1 sysctl -p
 	ssh root@isucon1 systemctl daemon-reload
 	ssh root@isucon1 systemctl restart mysql
 	ssh root@isucon1 systemctl restart nginx

--- a/etc/mysql/my.cnf
+++ b/etc/mysql/my.cnf
@@ -19,3 +19,13 @@
 
 !includedir /etc/mysql/conf.d/
 !includedir /etc/mysql/mysql.conf.d/
+
+[mysqld]
+bind-address = 0.0.0.0
+disable-log-bin
+thread_cache_size = 300
+innodb_buffer_pool_size = 1024M
+innodb_log_file_size = 16M
+innodb_flush_log_at_trx_commit = 2
+innodb_flush_method = O_DIRECT
+skip_innodb_doublewrite

--- a/etc/nginx/sites-enabled/isuride.conf
+++ b/etc/nginx/sites-enabled/isuride.conf
@@ -44,6 +44,11 @@ server {
   location /api/ {
     proxy_set_header Host $host;
     proxy_pass http://localhost:8080;
+    proxy_set_header Connection '';
+    proxy_http_version 1.1;
+    chunked_transfer_encoding off;
+    proxy_buffering off;
+    proxy_cache off;
   }
 
   location /api/internal/ {

--- a/etc/sysctl.conf
+++ b/etc/sysctl.conf
@@ -63,3 +63,10 @@
 #kernel.sysrq=438
 
 net.ipv4.ip_local_port_range=10000 65535
+
+net.core.somaxconn = 10000
+net.ipv4.ip_local_port_range = 10000 60999
+net.ipv4.tcp_tw_reuse = 1
+net.ipv4.tcp_fin_timeout = 10
+net.ipv4.tcp_max_tw_buckets = 2000000
+net.core.netdev_max_backlog = 8192


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and performance of the system. The most important changes include updates to the `Makefile`, `my.cnf`, `isuride.conf`, and `sysctl.conf` files.

Configuration updates:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R22): Added a command to reload system configurations with `sysctl -p` in the `deploy-conf` target.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R47-R49): Added a new target `install-redis` to install the Redis server on the remote machine.

MySQL configuration improvements:

* [`etc/mysql/my.cnf`](diffhunk://#diff-68c2af1951dd7958ea2f65bd588c7d225ba71378a9b303acf57512b8bdc77e56R22-R31): Added new configuration settings to optimize MySQL performance, including `bind-address`, `thread_cache_size`, and various InnoDB settings.

Nginx configuration enhancements:

* [`etc/nginx/sites-enabled/isuride.conf`](diffhunk://#diff-8be462bcadaab4d98916006bc649c00c8547b44732c8a5b05bb1e27b2d71633dR47-R51): Updated the `/api/` location block to improve performance by setting `proxy_http_version`, disabling `chunked_transfer_encoding`, and turning off `proxy_buffering` and `proxy_cache`.

System settings adjustments:

* [`etc/sysctl.conf`](diffhunk://#diff-25dbcf8fef9feb9db6bb4006e71bbfa7a41bc7fd0ccb3face84752da72222e22R66-R72): Added several network-related settings to improve TCP performance and connection handling, such as `net.core.somaxconn`, `net.ipv4.tcp_tw_reuse`, and `net.core.netdev_max_backlog`.