### PR TITLE
appGetNotification 間隔パラメータを調整

### DIFF
--- a/go/app_handlers.go
+++ b/go/app_handlers.go
@@ -663,7 +663,7 @@ func appGetNotification(w http.ResponseWriter, r *http.Request) {
 	if err := tx.GetContext(ctx, ride, `SELECT * FROM rides_with_status WHERE user_id = ? ORDER BY id DESC LIMIT 1`, user.ID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			writeJSON(w, http.StatusOK, &appGetNotificationResponse{
-				RetryAfterMs: 30,
+				RetryAfterMs: 2000,
 			})
 			return
 		}
@@ -706,7 +706,7 @@ func appGetNotification(w http.ResponseWriter, r *http.Request) {
 			CreatedAt: ride.CreatedAt.UnixMilli(),
 			UpdateAt:  ride.UpdatedAt.UnixMilli(),
 		},
-		RetryAfterMs: 30,
+		RetryAfterMs: 100,
 	}
 
 	if ride.ChairID.Valid {


### PR DESCRIPTION
This pull request includes changes to the `appGetNotification` function in the `go/app_handlers.go` file to adjust the retry intervals for notifications.

Changes to retry intervals:

* Increased `RetryAfterMs` from 30 milliseconds to 2000 milliseconds when no rows are found in the `rides_with_status` table.
* Adjusted `RetryAfterMs` from 30 milliseconds to 100 milliseconds in the response structure.